### PR TITLE
Minimal port mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ Start a database (e.g. MongoDB)
 ```bash
 docker run -e MONGO_INITDB_DATABASE=strapi \
            -v `pwd`/db/:/data/db \
-           -p 27017 \
-           --name mongo \
+           --name strapi-mongo \
            -d mongo
 ```
 
@@ -40,12 +39,12 @@ Start strapi
 ```bash
 docker run -e APP_NAME=strapi-app \
            -e DATABASE_CLIENT=mongo \
-           -e DATABASE_HOST=mongo \
+           -e DATABASE_HOST=strapi-mongo \
            -e DATABASE_PORT=27017 \
            -e DATABASE_NAME=strapi \
            -v `pwd`/strapi-app:/usr/src/api/strapi-app \
            -v /usr/src/api/strapi-app/node_modules \
-           --link mongo \
+           --link strapi-mongo:mongo \
            -p 1337:1337 \
            --name strapi -d strapi/strapi
 ```


### PR DESCRIPTION
Using --link gives a container access to another containers exposed ports, so a port mapping is not necessary. Since most people are not interested in the data inside the database itself, we can remove the port mapping and avoid problems if the port is already used by a different mongo instance. (https://docs.docker.com/engine/reference/run/#expose-incoming-ports)

I also updated the mongo-container name and link to reduce the risk of name clashes on another devs PC.