### PR TITLE
Added port to localhost link

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ docker run -e APP_NAME=strapi-app \
            --name strapi -d strapi/strapi
 ```
 
-You should the be able to access your Strapi installation at [localhost](http://localhost:1337).
+You should the be able to access your Strapi installation at [localhost:1337](http://localhost:1337).
 
 ## Use as base image
 


### PR DESCRIPTION
The port should be visible in the localhost link. This is only a small change, but if I see a link to localhost I immediately associate it with port 80 (if there is no https in front of it). This should make the actual link and the one presented to the user more coherent.