### PR TITLE
Fix improper Docker stop handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ RUN chmod +x ./strapi.sh
 
 EXPOSE 1337
 
-CMD ./strapi.sh
+CMD ["./strapi.sh"]

--- a/strapi.sh
+++ b/strapi.sh
@@ -1,6 +1,14 @@
 #!/bin/sh
 set -ea
 
+_stopStrapi() {
+  echo "Stopping strapi"
+  kill -SIGINT "$strapiPID"
+  wait "$strapiPID"
+}
+
+trap _stopStrapi SIGTERM SIGINT
+
 cd /usr/src/api
 
 APP_NAME=${APP_NAME:-strapi-app}
@@ -15,4 +23,7 @@ then
 fi
 
 cd $APP_NAME
-strapi start
+strapi start &
+
+strapiPID=$!
+wait "$strapiPID"


### PR DESCRIPTION
Trying to stop the container using `Docker stop` results in Docker killing the container (exit 137). This is because Docker uses SIGTERM as its stop signal and strapi expects SIGINT (CTRL-C) as its stop signal.

This PR changes the CMD format in the Dockerfile to the exec-format, so the wrapper-script will be executed as PID 1 (and can receive the stop signal), and traps the stop signal in the wrapper-script to send the correct signal to strapi.

We cannot use STOPSIGNAL in the Dockerfile as SIGINT is a signal that will not be passed to PID 1.