### PR TITLE
Automated docker hub preparation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# https://docs.docker.com/engine/reference/builder/#dockerignore-file
+# Don't send the following files to the docker daemon as the build context.
+
+.git
+.gitattributes
+.travis.yml
+README.md
+docker-compose.yml

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# https://help.github.com/articles/dealing-with-line-endings/
+
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Dockerfile and YAML files are text files as well
+Dockerfile text
+*.yml text
+
+# Shell scripts should always use LF line endings, otherwise the Docker base image might cause problems
+*.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,9 +3,10 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto
 
-# Dockerfile and YAML files are text files as well
 Dockerfile text
 *.yml text
+*.md text
+.dockerignore text
 
 # Shell scripts should always use LF line endings, otherwise the Docker base image might cause problems
 *.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node:9.8.0-alpine
 
 LABEL maintainer="Luca Perret <perret.luca@gmail.com>" \
       org.label-schema.vendor="Strapi" \
@@ -11,7 +11,7 @@ LABEL maintainer="Luca Perret <perret.luca@gmail.com>" \
 
 WORKDIR /usr/src/api
 
-RUN npm install -g strapi@alpha
+RUN npm install -g strapi@3.0.0-alpha.11
 
 COPY strapi.sh ./
 RUN chmod +x ./strapi.sh


### PR DESCRIPTION
A few optimisations to the code:
- .gitattributes will make sure that people don't accidentally change the line endings in the repository or mess up their own builds by checking out the shell-script using Windows line endings (this can lead to broken builds)
- .dockerignore will exclude all unnecessary files from the build context. In a short test it went down from 183kB to 5kB. Overall not much at the moment, but if the git-history grows so will the context over time.
- Dockerfile now uses a specific version of node as the base image and installs a specific version of strapi. This makes sure there are no surprise updates of node and allows us to build images with a tag that matches the strapi version. Building the same Dockerfile again will also not lead to different images (which might happen on a CI system that does not delete the images after a build and on a system that does keep them). 
**Hint**: The node version could probably be changed to 9-alpine or 9.8-alpine for the automated builds on Docker Hub, as those image-tags should be overriden by their latest patch / minor version builds automatically. Locally or on another CI systems, Docker will not look for a new 9-alpine image if one is already on the system, so a patch level update will not be downloaded as the tag is the same. For Docker Hub this should be different as a new patch level with the same 9-alpine tag will be actively pushed to the registry by the automatic builds of node. So for now I would keep the patch-level tag and update that regularly with new releases of strapi.

#5 