### PR TITLE
Add Docker healthcheck

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,4 @@ Dockerfile text
 
 # Shell scripts should always use LF line endings, otherwise the Docker base image might cause problems
 *.sh text eol=lf
+*.js text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,8 @@ RUN chmod +x ./strapi.sh
 
 EXPOSE 1337
 
+COPY healthcheck.js ./
+HEALTHCHECK --interval=15s --timeout=5s --start-period=30s \
+      CMD node /usr/src/api/healthcheck.js
+
 CMD ["./strapi.sh"]

--- a/healthcheck.js
+++ b/healthcheck.js
@@ -1,0 +1,26 @@
+const http = require("http");
+
+const options = {
+    host : "localhost",
+    port : "1337",
+    path: "/_health",
+    method: "HEAD",
+    timeout : 2000
+};
+
+const request = http.get(options, (res) => {
+    console.log(`STATUS: ${res.statusCode}`);
+    if (res.statusCode == 204) {
+        process.exit(0);
+    }
+    else {
+        process.exit(1);
+    }
+});
+
+request.on('error', function(err) {
+    console.error(`ERROR: ${err.message}`);
+    process.exit(1);
+});
+
+request.end();

--- a/healthcheck.js
+++ b/healthcheck.js
@@ -12,8 +12,7 @@ const request = http.get(options, (res) => {
     console.log(`STATUS: ${res.statusCode}`);
     if (res.statusCode == 204) {
         process.exit(0);
-    }
-    else {
+    } else {
         process.exit(1);
     }
 });


### PR DESCRIPTION
This is a first version / PoC for #6.

Added healthcheck.js that checks the `_health` route and expects a status code of 204.
Copy healthcheck file into image.
Added Docker healthcheck to run healthcheck.js using node.
js files always use LF line endings.