### PR TITLE
Updated strapi image name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 
 script:
-  - docker build -t strapi .
+  - docker build -t strapi/strapi-docker .
   - docker-compose up -d
   - sleep 60
   - curl -f localhost:1337

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 
 script:
-  - docker build -t strapi/strapi-docker .
+  - docker build -t strapi/strapi .
   - docker-compose up -d
   - sleep 60
   - curl -f localhost:1337

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   api:
-    image: strapi/strapi
+    image: strapi/strapi-docker
     environment:
       - APP_NAME=strapi-app
       - DATABASE_CLIENT=mongo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   api:
-    image: strapi/strapi-docker
+    image: strapi/strapi
     environment:
       - APP_NAME=strapi-app
       - DATABASE_CLIENT=mongo


### PR DESCRIPTION
I think there might have been a problem previously.
The image that was built was tagged as strapi but the image used in the `compose up` was actually strapi/strapi, which was being pulled from Docker Hub. So the image tested should have been a different image than the one that was built.

I only noticed that because the strapi/strapi repo was removed and recreated for #5 and now builds fail because they cannot pull from there again. The change now tags the image that is build from the current code as strapi/strapi-docker and uses the new docker hub repository in the compose-file. So the CI should use the newly build image and other users can still use it to get the image from docker hub (once the first automated built on master triggered).

I haven't been able to test the changes yet, as I cannot trigger the CI, so fingers crossed that it works. :)