### PR TITLE
Update Strapi to version 3.0.0-alpha.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,11 @@ LABEL maintainer="Luca Perret <perret.luca@gmail.com>" \
 
 WORKDIR /usr/src/api
 
+ARG STRAPI_VERSION=3.0.0-alpha.17
+
 RUN echo "unsafe-perm = true" >> ~/.npmrc
 
-RUN npm install -g strapi@3.0.0-alpha.16
+RUN npm install -g strapi@$STRAPI_VERSION
 
 COPY strapi.sh ./
 RUN chmod +x ./strapi.sh


### PR DESCRIPTION
Put strapi version in a docker ARG, it can be used for parametrized build

References #76 