### PR TITLE
Update to Beta with node 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:11.1.0-alpine
+FROM node:10-alpine
 
 LABEL maintainer="Luca Perret <perret.luca@gmail.com>" \
       org.label-schema.vendor="Strapi" \
@@ -13,7 +13,10 @@ WORKDIR /usr/src/api
 
 RUN echo "unsafe-perm = true" >> ~/.npmrc
 
-RUN npm install -g strapi@alpha
+RUN apk add --no-cache \
+  autoconf automake gcc libc-dev libtool make nasm zlib-dev && \
+  npm install -g strapi@beta && \
+  apk del libtool nasm
 
 COPY strapi.sh ./
 RUN chmod +x ./strapi.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,16 @@ WORKDIR /usr/src/api
 RUN echo "unsafe-perm = true" >> ~/.npmrc
 
 RUN apk add --no-cache \
-  autoconf automake gcc libc-dev libtool make nasm zlib-dev && \
-  npm install -g strapi@beta && \
-  apk del libtool nasm
+  autoconf \
+  automake \
+  gcc \
+  libc-dev \
+  libtool \
+  make \
+  nasm \
+  zlib-dev
+
+RUN npm install -g strapi@beta
 
 COPY strapi.sh ./
 RUN chmod +x ./strapi.sh


### PR DESCRIPTION
Modified #120 by using Node 10 and adding/removing build packages. The image builds and Strapi starts successfully.

Tried my best to keep the image lean by adding build packages directly instead of using build-base, and the final result was "144 MiB in 34 packages" (~150MB). Removing any more build package led to failure.

Docker hub link: https://hub.docker.com/r/bobaekang/strapi