### PR TITLE
fix permission issue

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@
 .travis.yml
 README.md
 docker-compose.yml
+db


### PR DESCRIPTION
Based on the docker library repository we have to hide in .dockerignore the database mounted folder due to produce an error in the second run. Also, I got this error message multiple times.

[Link issue](https://github.com/docker-library/mongo/issues/337)