### PR TITLE
Move Database into a Docker Volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,5 +31,9 @@ services:
     ports:
       - 27017:27017
     volumes:
-      - ./db:/data/db
+      - strapi_mongodb_data:/data/db
     restart: always
+
+volumes:
+    strapi_mongodb_data:
+        driver: local


### PR DESCRIPTION
For mongodb (and this applies to other containers as well, mainly databases) bind mounts on Windows and OS X are not support.
So to Fix #80 we move its data into its own volume