### PR TITLE
Fix npm locker filename in docker-entrypoint.sh

### DIFF
--- a/strapi/docker-entrypoint.sh
+++ b/strapi/docker-entrypoint.sh
@@ -30,7 +30,7 @@ if [ "$1" = "strapi" ]; then
 
       yarn install
 
-    elif [ -f "package-json.lock" ]; then
+    elif [ -f "package-lock.json" ]; then
 
       npm install
 


### PR DESCRIPTION
I've fixed a typo in the npm locker filename.
With this error, automatic installation of `node_modules` with npm is not triggered.