### PR TITLE
Addresses targeting multi-os w/ docker-compose

### DIFF
--- a/strapi/docker-entrypoint.sh
+++ b/strapi/docker-entrypoint.sh
@@ -22,7 +22,7 @@ if [ "$1" = "strapi" ]; then
       --dbssl=$DATABASE_SSL \
       $EXTRA_ARGS
 
-  elif [ ! -d "node_modules" ] || [ ! "$(ls -A node_modules)" ]; then
+  elif [ ! -d "node_modules" ] || [ ! "$(ls -qAL node_modules 2>/dev/null)" ]; then
 
     echo "Node modules not installed. Installing..."
 

--- a/strapi/docker-entrypoint.sh
+++ b/strapi/docker-entrypoint.sh
@@ -22,7 +22,7 @@ if [ "$1" = "strapi" ]; then
       --dbssl=$DATABASE_SSL \
       $EXTRA_ARGS
 
-  elif [ ! -d "node_modules" ]; then
+  elif [ ! -d "node_modules" ] || [ ! "$(ls -A node_modules)" ]; then
 
     echo "Node modules not installed. Installing..."
 


### PR DESCRIPTION
Allows use of docker-compose when atrgetting multi-os (e.g. dev machine doesn't match strapi's *nix base image).

**Primary change:**

* Install dependencies when `node_modules` either does not exists or is empty.

**Additional change(s) needed:**

Suggested add `postinstall` step to `package.json` which calls `strapi build` (to avoid issues with `build\index.html` not being present).

**Example**

`$ npx strapi new example --quickstart --no-run`
`$ touch docker-compose.yml`
Insert content:

```
version: "3.4"

services:
  app:
    image: strapi/strapi:3.0.2
    container_name: strapi
    restart: unless-stopped
    networks:
      - strapi-network
    volumes:
      # reference code locally and push to container
      - .:/srv/app
      # Have docker only reference local copies of these volumes as to not disrupt
      # local (os-specific) dependencies. note: If you rely solely on .dockerignore, while
      # they won't be copied to container, it will try to write files back to your local (host)
      # machine. These will avoid that.
      - /srv/app/.cache
      - /srv/app/.tmp
      - /srv/app/build
      - /srv/app/node_modules
    ports:
      - "1337:1337"
    healthcheck:
      test: ["CMD", "curl", "-i", "-x", "HEAD", "-f", "http://localhost:1337/_health"]
      interval: 1m30s
      timeout: 10s
      retries: 3
      start_period: 40s

networks:
  strapi-network:
    driver: bridge
```

Also, if you're using mongo (and have it setup), another example:

```
version: "3.4"

services:
  app:
    image: strapi/strapi:3.0.2
    container_name: strapi
    restart: unless-stopped
    environment:
      NODE_ENV: production
      MONGODB_URI: mongodb://mongo:27017/strapi
    depends_on:
      - mongo
    networks:
      - strapi-network
    volumes:
      - .:/srv/app
      - /srv/app/.cache
      - /srv/app/.tmp
      - /srv/app/build
      - /srv/app/node_modules
    ports:
      - "1337:1337"
    healthcheck:
      test: ["CMD", "curl", "-i", "-x", "HEAD", "-f", "http://localhost:1337/_health"]
      interval: 1m30s
      timeout: 10s
      retries: 3
      start_period: 40s

  mongo:
    image: mongo
    container_name: mongo
    restart: unless-stopped
    networks:
      - strapi-network
    volumes:
      - mongodata:/data/db
    ports:
      - "27017:27017"
  
  mongo-express:
    image: mongo-express
    container_name: mongo-express
    restart: unless-stopped
    environment:
      ME_CONFIG_BASICAUTH_USERNAME: strapi
      ME_CONFIG_BASICAUTH_PASSWORD: strapi
    depends_on:
      - mongo
    networks:
      - strapi-network
    ports:
      - "8081:8081"

networks:
  strapi-network:
    driver: bridge

volumes:
  mongodata:
```