### PR TITLE
Make strapi directory owned by node user

### DIFF
--- a/strapi/Dockerfile
+++ b/strapi/Dockerfile
@@ -4,6 +4,8 @@ FROM strapi/base:${BASE_VERSION}
 ARG STRAPI_VERSION
 RUN yarn global add strapi@${STRAPI_VERSION}
 
+RUN mkdir /srv/app && chown 1000:1000 -R /srv/app
+
 WORKDIR /srv/app
 
 VOLUME /srv/app


### PR DESCRIPTION
With the current version of the Dockerimage it isn't possible to run strapi with another user besides root. If you try to run it with user 1000 you'll get an error message indicating that the user does not have write permissions for the directory `/srv/app`. This PR make user 1000 the owner of the directory.