### PR TITLE
Update alpine/Dockerfile

### DIFF
--- a/base/alpine/Dockerfile
+++ b/base/alpine/Dockerfile
@@ -1,6 +1,6 @@
 ARG NODE_VERSION
 FROM node:${NODE_VERSION}
 
-RUN apk update && apk upgrade && apk add build-base gcc autoconf automake zlib-dev libpng-dev nasm bash
+RUN apk add --no-cache build-base gcc autoconf automake zlib-dev libpng-dev nasm bash
 
 EXPOSE 1337


### PR DESCRIPTION
It's considered better to use `--no-cache` with `apk` in Docker since it's better suited for Dockers caching of layers etc and requires fewer steps.