### PR TITLE
fix: show strapi version

### DIFF
--- a/strapi/docker-entrypoint.sh
+++ b/strapi/docker-entrypoint.sh
@@ -9,7 +9,7 @@ if [ "$1" = "strapi" ]; then
 
     EXTRA_ARGS=${EXTRA_ARGS}
 
-    echo "Using strapi $(strapi -v)"
+    echo "Using strapi $(strapi version)"
     echo "No project found at /srv/app. Creating a new strapi project"
 
     DOCKER=true strapi new . \


### PR DESCRIPTION
Passing `version` instead of `-v` makes Strapi now show its version number.