### PR TITLE
added missing build step to access admin end

### DIFF
--- a/examples/prod/docker-compose.yml
+++ b/examples/prod/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - ./app:/srv/app
     depends_on:
       - db
-    command: 'strapi start'
+    command: bash -c "strapi build && strapi start"
 
   db:
     container_name: postgres


### PR DESCRIPTION
This pull request fixes the error ` Error: ENOENT: no such file or directory, open '/srv/app/build/index.html'` when strapi is run in production. 

The cause of the error is the missing build step for the admin dashboard and the fix is to add the command 
`bash -c "strapi build && strapi start"` 

