### PR TITLE
fix: scoped v4 strapi package for yarn pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The most advanced open-source Content Management Framework to build powerful API
 ---
 
 [![Travis](https://img.shields.io/travis/strapi/strapi-docker.svg?style=for-the-badge)](https://travis-ci.org/strapi/strapi-docker)
-[![Docker Pulls](https://img.shields.io/docker/pulls/strapi/strapi.svg?style=for-the-badge)](https://hub.docker.com/r/strapi/strapi) 
+[![Docker Pulls](https://img.shields.io/docker/pulls/strapi/strapi.svg?style=for-the-badge)](https://hub.docker.com/r/strapi/strapi)
 
 ## Images
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The most advanced open-source Content Management Framework to build powerful API
 ---
 
 [![Travis](https://img.shields.io/travis/strapi/strapi-docker.svg?style=for-the-badge)](https://travis-ci.org/strapi/strapi-docker)
-[![Docker Pulls](https://img.shields.io/docker/pulls/strapi/strapi.svg?style=for-the-badge)](https://hub.docker.com/r/strapi/strapi)
+[![Docker Pulls](https://img.shields.io/docker/pulls/strapi/strapi.svg?style=for-the-badge)](https://hub.docker.com/r/strapi/strapi) 
 
 ## Images
 

--- a/strapi/Dockerfile
+++ b/strapi/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_VERSION
 FROM strapi/base:${BASE_VERSION}
 
 ARG STRAPI_VERSION
-RUN yarn global add strapi@${STRAPI_VERSION}
+RUN yarn global add @strapi/strapi@${STRAPI_VERSION}
 
 RUN mkdir /srv/app && chown 1000:1000 -R /srv/app
 


### PR DESCRIPTION
Intended on fixing #321

New versions of strapi have been scoped behind `@strapi/strapi`. 

This change allows future docker images to be built properly with the new scoped npm package. 