### PR TITLE
fix: scoped v4 strapi package for yarn pull

### DIFF
--- a/strapi/Dockerfile
+++ b/strapi/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_VERSION
 FROM strapi/base:${BASE_VERSION}
 
 ARG STRAPI_VERSION
-RUN yarn global add strapi@${STRAPI_VERSION}
+RUN yarn global add @strapi/strapi@${STRAPI_VERSION}
 
 RUN mkdir /srv/app && chown 1000:1000 -R /srv/app
 


### PR DESCRIPTION
Intended on fixing #321

New versions of strapi have been scoped behind @strapi/strapi.

This change allows future docker images to be built properly with the new scoped npm package.